### PR TITLE
Fix #1: Unexpected tool name 'previewsave'

### DIFF
--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -5,8 +5,6 @@ import pretty_midi as pm
 from pretty_midi import TimeSignature
 
 from presets import PRESET_4K
-from visual_midi import Preset
-
 from visual_midi import Coloring
 from visual_midi.visual_midi import Plotter
 

--- a/visual_midi/visual_midi.py
+++ b/visual_midi/visual_midi.py
@@ -121,7 +121,7 @@ class Plotter:
 
     # Initialize the tools, those are present on the right hand side
     plot = bokeh.plotting.figure(
-      tools="reset,hover,previewsave,wheel_zoom,pan",
+      tools="reset,hover,save,wheel_zoom,pan",
       toolbar_location=preset.toolbar_location)
 
     # Setup the hover and the data dict for bokeh,


### PR DESCRIPTION
Use tool name 'save' instead of 'previewsave' which was removed in bokeh
version 2.0.0.